### PR TITLE
Consistent C interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ build
 .vs
 x64
 vscode
-
+staging

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ message("<<< Parsing libunistd/CMakeList.txt")
 message("--- Building ${PROJECT_NAME} ${CMAKE_SYSTEM_NAME}:${CMAKE_HOST_SYSTEM_PROCESSOR}:${CMAKE_GENERATOR_TOOLSET} ---")
 
 option(UE4 "Disable _ITERATOR_DEBUG_LEVEL for UE4 compatibility" OFF)
+option(WITH_TESTS "Enable this to build the tests / examples as well." OFF)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED FALSE)
@@ -41,5 +42,6 @@ add_subdirectory(sqlite)
 add_subdirectory(uuid)
 add_subdirectory(regex)
 add_subdirectory(xxhash)
-
+if(WITH_TESTS)
 add_subdirectory(test)
+endif()

--- a/lmdb/CMakeLists.txt
+++ b/lmdb/CMakeLists.txt
@@ -44,5 +44,6 @@ set(INCDIR
 
 add_library(${PROJECT_NAME} STATIC ${SOURCES})
 target_include_directories(${PROJECT_NAME} PUBLIC ${INCDIR})
-
+if(WITH_TESTS)
 add_subdirectory(test)
+endif()

--- a/portable/SystemLog.h
+++ b/portable/SystemLog.h
@@ -10,7 +10,6 @@
 #include <string.h>
 #include <errno.h>
 #include <stdio.h>
-#include <stdio.h>
 
 #if defined(_WIN32) && defined(_DEBUG)
 #include <crtdbg.h>

--- a/unistd/CMakeLists.txt
+++ b/unistd/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(libunistd
     dirent.cpp
 	unistd.h
 	getopt.cpp
+	pthread.cpp
 	gettimeofday.cpp
 	uni_signal.cpp
 	syslog.cpp

--- a/unistd/dirent.cpp
+++ b/unistd/dirent.cpp
@@ -9,8 +9,8 @@
 #include <string.h>
 #include <io.h>
 #include <direct.h>
-#include <list>
-#include <string>
+//#include <list>
+//#include <string>
 #include "dirent.h"
 #include "../portable/Finder.h"
 

--- a/unistd/pthread.cpp
+++ b/unistd/pthread.cpp
@@ -1,0 +1,108 @@
+
+#include "pthread.h"
+
+#include "../portable/Logger.h"
+
+#include <thread>
+#include <system_error>
+
+struct pthread_attr
+{	bool isJoinable;
+public:
+	pthread_attr()
+	:	isJoinable(true)
+	{}
+};
+typedef struct pthread_attr pthread_attr_t;
+
+struct PortableThread
+:	public std::thread
+{	
+public:
+	pthread_attr_t attr;
+	PortableThread(const pthread_attr_t *attr,void *(*start_routine) (void *), void *arg)
+	:	std::thread(start_routine,arg)
+	{	if(attr)
+		{	this->attr = *attr;
+	}	}
+};
+
+int pthread_setschedparam(pthread_t pthread, int policy, const sched_param* param)
+{	if(!pthread)
+	{	return -1;
+	}
+	HANDLE h = (HANDLE) pthread->native_handle();
+	return SetThreadPriority(h, param->sched_priority)? 0:-1;
+}
+
+#ifdef VERBOSE_PTHREAD
+int uni_pthread_create(pthread_t* pthread, const pthread_attr_t *attr,void *(*start_routine) (void *), void *arg,const char* name)
+{	SysLogMsg("Thread",name); 
+	PortableThread* t=new PortableThread(attr,start_routine,arg);
+	*pthread=t;
+	if(!t->attr.isJoinable)
+	{	t->detach();
+	}
+	return 0;
+}
+
+#define pthread_create(t,at,f,arg) uni_pthread_create(t,at,f,arg,#f)
+#else
+int pthread_create(pthread_t* pthread, const pthread_attr_t *attr,void *(*start_routine) (void *), void *arg)
+{	PortableThread* t=0;
+    try 
+	{	t = new PortableThread(attr,start_routine,arg);
+    } 
+	catch(const std::system_error& e) 
+	{	printf("Caught system_error %s\n",e.what());
+		return -1;
+    }
+	*pthread=t;
+	if(!t->attr.isJoinable)
+	{	t->detach();
+	}
+	return 0;
+}
+#endif
+
+int pthread_attr_setdetachstate(pthread_attr_t *attr, ThreadState detachstate)
+{	if(!attr)
+	{	return -1;
+	}
+	attr->isJoinable = (detachstate == PTHREAD_CREATE_JOINABLE);
+	return 0;
+}
+
+int pthread_attr_getdetachstate(const pthread_attr_t *attr, int *detachstate)
+{	if(!attr)
+	{	return -1;
+	}
+	if(attr->isJoinable)
+	{	*detachstate = (int) PTHREAD_CREATE_JOINABLE;
+		return true;
+	}
+	*detachstate = (int) PTHREAD_CREATE_DETACHED;
+	return 0;
+}
+
+int pthread_join(pthread_t thread, void **retval)
+{	if(!thread)
+	{	return -1;
+	}
+	if(!thread->attr.isJoinable)
+	{	return -1;
+	}
+    try 
+	{	thread->join();
+    } 
+	catch(const std::system_error& e) 
+	{	printf("Caught system_error %s\n",e.what());
+		return -1;
+    }
+	return 0;
+}
+
+int pthread_detach(pthread_t thread)
+{	thread->detach();
+	return 0;
+}

--- a/unistd/syslog.cpp
+++ b/unistd/syslog.cpp
@@ -13,7 +13,22 @@
 // debugapi.h 
 #include "../portable/SystemLog.h"
 
+#include <string>
+
 #pragma warning(disable:4996)
+
+struct Syslog_data
+{	FILE* fp;
+//	int option;
+	int facility;
+	int mask;
+	std::string ident;
+	bool isTTY;
+};
+typedef
+	struct Syslog_data
+	Syslog_data
+	;
 
 Syslog_data syslog_data;
 

--- a/unistd/syslog.h
+++ b/unistd/syslog.h
@@ -5,18 +5,9 @@
 #ifndef syslog_h
 #define syslog_h
 
-#include <string>
+struct Syslog_data;
 
-struct Syslog_data
-{	FILE* fp;
-//	int option;
-	int facility;
-	int mask;
-	std::string ident;
-	bool isTTY;
-};
-
-extern Syslog_data syslog_data;
+//extern Syslog_data Syslog_data;
 
 // option:
 enum 

--- a/unistd/uni_signal.h
+++ b/unistd/uni_signal.h
@@ -10,6 +10,10 @@
 #include <memory.h>
 #include "../portable/stub.h"
 #include "sys/sys_types.h"
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -136,7 +140,7 @@ int sigismember(const sigset_t *set, int signum)
 }
 
 extern void (*CtrlCHandler)(int, struct siginfo_t *, void *);
-BOOL WindowsCtrlCHandler(DWORD fdwCtrlType) ;
+BOOL WindowsCtrlCHandler(DWORD fdwCtrlType);
 int sigaction(int signum, const struct sigaction* act, struct sigaction* oldact);
 
 inline

--- a/uuid/CMakeLists.txt
+++ b/uuid/CMakeLists.txt
@@ -44,5 +44,6 @@ set(SOURCES
 )
 
 add_library(${PROJECT_NAME} STATIC ${SOURCES})
-
+if(WITH_TESTS)
 add_subdirectory(test)
+endif()


### PR DESCRIPTION
Thank you for the great work you're doing on libunistd. Ran into issues using it for a
C project on windows. There were mixups of C and C++ standard libraries while
compiling. My approach was to move all C++ specific code and includes into their
respective compilation units, or create new ones if appropriates (as I deemed it to
be the case for pthread). Here are the details from the commit message:
```
Moved all c++ specific implementation details, as well as references to any STL header
to their respective compilation units. created a seperate compilation unit for pthread
as to allow for forward declaring the necessary structs in a consistent c fashion, while
implementing it in c++ in the unit. this allows for seperation of header use for c
without pulling in any STL header, as this will lead to compiler errors on windows.
for details checkout https://github.com/ofiwg/libfabric/issues/7041#issuecomment-914839351
or the STL commit https://github.com/microsoft/STL/pull/2148
```