### PR TITLE
Upstream more additions/changes

### DIFF
--- a/portable/Finder.h
+++ b/portable/Finder.h
@@ -15,6 +15,9 @@
 #include <string>
 #pragma comment(lib, "User32.lib")
 
+// WIN_NO_ERROR = NO_ERROR As we are undeffing `NO_ERROR` to avoid naming collision in unistd.h
+#define WIN_NO_ERROR 0
+
 namespace portable {
 
 class Finder
@@ -28,7 +31,7 @@ class Finder
 	void Reset()
 	{	memset(this,0,sizeof(*this));
 		h = INVALID_HANDLE_VALUE;
-		error = NO_ERROR;//ERROR_NO_MORE_FILES;
+		error = WIN_NO_ERROR;//ERROR_NO_MORE_FILES;
 	}
 #pragma warning(disable:4996)
 #pragma warning(disable:26495)
@@ -68,7 +71,7 @@ class Finder
 	{	if(h == INVALID_HANDLE_VALUE)
 		{	return false;
 		}
-		if(error != ERROR_NO_MORE_FILES && error != NO_ERROR)
+		if(error != ERROR_NO_MORE_FILES && error != WIN_NO_ERROR)
 		{	return false;
 		}
 		return true;

--- a/portable/time/VariableClock.h
+++ b/portable/time/VariableClock.h
@@ -5,13 +5,8 @@
 #ifndef VariableClock_h
 #define VariableClock_h
 
-#ifdef _WIN32
 #include <unistd.h>
 #include <sys/time.h>
-#else
-#include <unistd.h>
-#include <sys/time.h>
-#endif
 #include <time.h>
 
 namespace portable

--- a/regex/regex.cpp
+++ b/regex/regex.cpp
@@ -42,9 +42,7 @@ const std::map<error_type, int> ERROR_TYPE =
 	{error_space, REG_ESPACE},
 	{error_badrepeat, REG_BADRPT},
 	{error_complexity, REG_ESIZE},
-	{error_stack, REG_ESIZE},
-	{error_parse, REG_BADPAT},
-	{error_syntax, REG_BADPAT}
+	{error_stack, REG_ESIZE}
 };
 
 int getErrorCode(error_type err)

--- a/unistd/libgen.h
+++ b/unistd/libgen.h
@@ -8,6 +8,7 @@
 #define libgen_h
 
 #include <string.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,7 +18,23 @@ extern "C" {
 
 inline
 const char* dirname(char *path)
-{	return "error";
+{	char drive[_MAX_DRIVE] = { 0 };
+	char dir[_MAX_DIR] = { 0 };
+	errno_t error = _splitpath_s(path, drive, _MAX_DRIVE, dir, _MAX_DIR, NULL, 0, NULL, 0);
+	if (error)
+	{	return NULL;
+	}
+	char result[_MAX_PATH] = { 0 };
+	error = _makepath_s(result, drive, dir, NULL, NULL);
+	if (error)
+	{	return NULL;
+	}
+	// Modifying path in-place to match GNU implementation's behavior.
+	error = strncpy_s(path, strlen(path) + 1, result, _MAX_PATH);
+	if (error && error != STRUNCATE)
+	{	return NULL;
+	}
+	return path;
 }
 
 inline 

--- a/unistd/sigaction.h
+++ b/unistd/sigaction.h
@@ -148,6 +148,11 @@ int sigprocmask(int how, const sigset_t *set, sigset_t *oldset)
 }
 
 inline
+int pthread_sigmask(int how, const sigset_t *set, sigset_t *oldset)
+{	return sigprocmask(how, set, oldset);
+}
+
+inline
 int sigpending(sigset_t *set)
 {	(void)set;
 	STUB_0(sigpending);

--- a/unistd/sigaction.h
+++ b/unistd/sigaction.h
@@ -42,6 +42,10 @@ SIGTERM Termination request
 */
 
 #define WNOHANG 0
+#define SIG_UNBLOCK 1
+#define SIG_BLOCK 2
+#define WIFSIGNALED() false
+#define WTERMSIG() 0
 
 typedef struct siginfo_t siginfo_t;
 

--- a/unistd/sys/poll.h
+++ b/unistd/sys/poll.h
@@ -5,7 +5,6 @@
 #ifndef sys_poll_h
 #define sys_poll_h
 
-#if _MSC_VER <= 1900
 #include <unistd.h>
 
 typedef WSAPOLLFD pollfd;
@@ -16,5 +15,4 @@ int poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {	return WSAPoll(fds,nfds,timeout);
 }
 
-#endif
 #endif

--- a/unistd/sys/socket.h
+++ b/unistd/sys/socket.h
@@ -2,10 +2,13 @@
 #define socket_h
 
 #define WIN32_LEAN_AND_MEAN
+#define CONST const
 #include <winsock2.h>
 #include <windows.h>
+#define VOID void
 #include <Mstcpip.h>
 #include <Ws2tcpip.h>
+#undef VOID
 #include <stdint.h>
 #include "stub.h"
 #include "cfunc.h"

--- a/unistd/sys/socket.h
+++ b/unistd/sys/socket.h
@@ -31,7 +31,7 @@ struct msghdr
 	int msg_flags;
 };
 
-typedef int caddr_t;
+typedef uint8_t* caddr_t;
 
 // The ioctlsocket function and the WSAIoctl function handle socket functions that were performed by IOCTL and fcntl in BSD
 

--- a/unistd/sys/socket.h
+++ b/unistd/sys/socket.h
@@ -32,6 +32,10 @@ typedef int caddr_t;
 
 // The ioctlsocket function and the WSAIoctl function handle socket functions that were performed by IOCTL and fcntl in BSD
 
+inline int inet_aton(const char* cp, struct in_addr* inp)
+{	return inet_pton(AF_INET, cp, inp);
+}
+
 /* FYI, how to do TCP_KEEPCNT in linux/windows:
 #ifndef _WIN32
     int count = 10;

--- a/unistd/sys/sys_types.h
+++ b/unistd/sys/sys_types.h
@@ -21,6 +21,15 @@ typedef int gid_t;
 typedef int uid_t;
 typedef int Atom;
 
+#ifndef _WINSOCK2API_
+// Winsock2 already defines these typedefs.
+// In order to avoid including winsock2.h we define them only of winsock2 wasn't already included.
+typedef unsigned char   u_char;
+typedef unsigned short  u_short;
+typedef unsigned int    u_int;
+typedef unsigned long   u_long;
+#endif
+
 enum
 {	F_DUPFD, 
 	F_GETFD,

--- a/unistd/sys/sys_types.h
+++ b/unistd/sys/sys_types.h
@@ -15,11 +15,17 @@ typedef int sigval_t;
 typedef int sigset_t;
 typedef unsigned short ushort;
 typedef	int key_t;
-typedef long long ssize_t;
 typedef unsigned short mode_t;
 typedef int gid_t;
 typedef int uid_t;
 typedef int Atom;
+
+#if defined(_MSC_VER)
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
+#else
+typedef int ssize_t;
+#endif
 
 #ifndef _WINSOCK2API_
 // Winsock2 already defines these typedefs.
@@ -31,12 +37,12 @@ typedef unsigned long   u_long;
 #endif
 
 enum
-{	F_DUPFD, 
+{	F_DUPFD,
 	F_GETFD,
-	F_SETFD, 
-	F_GETFL, 
-	F_SETFL, 
-	F_GETLK, 
+	F_SETFD,
+	F_GETFL,
+	F_SETFL,
+	F_GETLK,
 	F_SETLK,
 	F_SETLKW,
 	FD_CLOEXEC

--- a/unistd/sys/time.h
+++ b/unistd/sys/time.h
@@ -91,6 +91,8 @@ struct tm *localtime_r(const time_t *t, struct tm *result)
 	return err ? nullptr:result;
 }
 
+#define timegm _mkgmtime
+
 #ifdef __cplusplus
 }
 #endif

--- a/unistd/sys/types.h
+++ b/unistd/sys/types.h
@@ -1,0 +1,11 @@
+// sys/types.h
+// Copyright (c) 2022/10/19 Tomer Lev <tomerlev@microsoft.com>
+// License open source MIT
+
+#ifndef sys_types_h
+#define sys_types_h
+
+#include "sys/sys_types.h"
+#include <../ucrt/sys/types.h>
+
+#endif

--- a/unistd/unistd.cpp
+++ b/unistd/unistd.cpp
@@ -507,6 +507,10 @@ long int random()
 {	return rand();
 }
 
+void srandom(unsigned int seed)
+{ 	srand(seed);
+}
+
 #if 0
 int sleep(useconds_t seconds)
 {	Sleep((DWORD)(1000*seconds));
@@ -539,4 +543,19 @@ int fseeko(FILE *stream, off_t offset, int whence)
 
 off_t ftello(FILE *stream)
 {	return ftell(stream);
+}
+
+ssize_t pwrite(int fildes, const void *buf, size_t nbyte, off_t offset)
+{	if (nbyte == 0)
+	{	return 0;
+	}
+	OVERLAPPED overlapped;
+	memset(&overlapped, 0, sizeof(overlapped));
+	overlapped.Offset = static_cast<DWORD>(offset);
+	overlapped.OffsetHigh = offset >> 32;
+	DWORD written;
+	if (!WriteFile((HANDLE)_get_osfhandle(fildes), buf, static_cast<DWORD>(nbyte), &written, &overlapped))
+	{	return -1;
+	}
+	return written;
 }

--- a/unistd/unistd.cpp
+++ b/unistd/unistd.cpp
@@ -559,3 +559,23 @@ ssize_t pwrite(int fildes, const void *buf, size_t nbyte, off_t offset)
 	}
 	return written;
 }
+
+int setlinebuf(FILE *stream)
+{	return setvbuf(stream, NULL, _IONBF, 0);
+}
+
+int vasprintf(char **ptr, const char *format, va_list arg)
+{	int n = _vscprintf(format, arg);
+	if (n < 0)
+		return -1;
+	char *p = (char *)malloc(n+1);
+	if (p == NULL)
+		return -1;
+	int rv = vsprintf_s(p, n+1, format, arg);
+	if (rv < 0)
+	{	free(p);
+		return -1;
+	}
+	*ptr = p;
+	return rv;
+}

--- a/unistd/unistd.cpp
+++ b/unistd/unistd.cpp
@@ -209,7 +209,7 @@ char* realpath(const char *path, char *resolved_path)
 	{	return 0;
 	}
 	const DWORD  err = GetFullPathNameA(path,(DWORD) PATH_MAX,resolved_path,0);
-	if(err)
+	if(err == 0)
 	{	return 0;
 	}
 	return resolved_path;

--- a/unistd/unistd.cpp
+++ b/unistd/unistd.cpp
@@ -28,12 +28,13 @@ int setpgrp(pid_t pid, pid_t pgid) /* BSD version */
 
 #pragma warning(disable : 4996)
 
-/*
-inline
 int read(int fh,void* buf,unsigned count)
 {	return _read(fh,buf,count);
 }
-*/
+
+int pipe(int pipes[2])
+{	return _pipe((pipes), 8*1024, _O_BINARY);
+}
 
 int snprintb(char *buf, size_t buflen, const char *fmt, uint64_t val)
 {	(void)buf;

--- a/unistd/unistd.cpp
+++ b/unistd/unistd.cpp
@@ -580,3 +580,11 @@ int vasprintf(char **ptr, const char *format, va_list arg)
 	*ptr = p;
 	return rv;
 }
+
+int asprintf(char **ret, const char *format, ...)
+{	va_list ap;
+	va_start(ap, format);
+	int retval = vasprintf(ret, format, ap);
+	va_end(ap);
+	return retval;
+}

--- a/unistd/unistd.h
+++ b/unistd/unistd.h
@@ -179,7 +179,6 @@ CFUNC int vasprintf(char **strp, const char *fmt, va_list ap);
 #define LONG_LONG_MAX LLONG_MAX     
 #define LONG_LONG_MIN LLONG_MIN     
 #define strdup _strdup
-#define vsnprintf _vsnprintf
 //#define sscanf uni_sscanf
 #undef MAX_PRIORITY /* remove winspool.h warning */
 #ifndef strcasecmp

--- a/unistd/unistd.h
+++ b/unistd/unistd.h
@@ -164,6 +164,9 @@ CFUNC off_t ftello(FILE *stream);
 CFUNC char* strptime(const char* s, const char* format,struct tm* tm);
 CFUNC ssize_t getline(char** lineptr, size_t* n,FILE* stream);
 CFUNC ssize_t getdelim(char** lineptr, size_t* n,int delim, FILE* stream);
+CFUNC ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
+CFUNC int setlinebuf(FILE *stream);
+CFUNC int vasprintf(char **strp, const char *fmt, va_list ap);
 
 //#define strlen unistd_safe_strlen
 //#define inet_ntop InetNtop

--- a/unistd/unistd.h
+++ b/unistd/unistd.h
@@ -30,7 +30,6 @@
 #include <direct.h>
 #include <winerror.h>
 #include <memory.h>
-#include <mswsock.h> //for SO_UPDATE_ACCEPT_CONTEXT
 #include <Ws2tcpip.h>//for InetNtop
 #include <ctype.h>
 #include <time.h>

--- a/unistd/unistd.h
+++ b/unistd/unistd.h
@@ -62,6 +62,7 @@ CFUNC int opterr;
 CFUNC int optopt;
 
 typedef long long useconds_t;
+typedef unsigned int uint;
 
 enum 
 {	F_LOCK=1,
@@ -218,8 +219,6 @@ CFUNC int vasprintf(char **strp, const char *fmt, va_list ap);
 #define pipe(pipes) _pipe((pipes),8*1024,_O_BINARY)
 #ifndef __has_attribute
 #define   __attribute__(x)
-#endif
-//__attribute__((format (printf, 1, 2)))
 #define mkdir mkdir2
 #define fileno _fileno
 #define open uni_open
@@ -233,5 +232,35 @@ CFUNC int vasprintf(char **strp, const char *fmt, va_list ap);
 #define SSIZE_MAX SIZE_MAX
 #define SIGTRAP 23
 
+// Defined unsupported macro as empty.
+#define __builtin_unreachable()
+
+// Remove defines that cause collisions.
+#undef min
+#undef max
+#undef close
+#undef CONST
+#undef ERROR
+#undef IGNORE
+#undef STATUS_INVALID_HANDLE
+#undef STATUS_INVALID_PARAMETER
+#undef Yield
+#undef CompareString
+#undef NO_ERROR
+
+#if _MSC_VER < 1930
+// Workaround negative character values that caused asserts on VS 2019 and below
+#define isalpha(ch) isalpha((unsigned char)(ch))
+#define isupper(ch) isupper((unsigned char)(ch))
+#define islower(ch) islower((unsigned char)(ch))
+#define isdigit(ch) isdigit((unsigned char)(ch))
+#define isspace(ch) isspace((unsigned char)(ch))
+#define ispunct(ch) ispunct((unsigned char)(ch))
+#define isblank(ch) isblank((unsigned char)(ch))
+#define isalnum(ch) isalnum((unsigned char)(ch))
+#define isprint(ch) isprint((unsigned char)(ch))
+#define isgraph(ch) isgraph((unsigned char)(ch))
+#define iscntrl(ch) iscntrl((unsigned char)(ch))
 #endif
 
+#endif

--- a/unistd/unistd.h
+++ b/unistd/unistd.h
@@ -63,11 +63,11 @@ CFUNC int optopt;
 typedef long long useconds_t;
 typedef unsigned int uint;
 
-enum 
+enum
 {	F_LOCK=1,
 	F_TLOCK,
 	F_ULOCK,
-	F_TEST 
+	F_TEST
 };
 
 #ifdef _BSD_SOURCE
@@ -76,6 +76,8 @@ CFUNC pid_t getpgrp(pid_t pid); /* BSD version */
 CFUNC pid_t getpgrp(); /* POSIX.1 version */
 #endif
 CFUNC int setpgrp(pid_t pid, pid_t pgid); 
+CFUNC int read(int fh, void* buf, unsigned count);
+CFUNC int pipe(int pipes[2]);
 //CFUNC int uni_open(const char* filename,unsigned oflag,int mode);
 CFUNC int uni_open(const char* filename, unsigned oflag,...);
 CFUNC int fcntl(int handle, int mode,...);
@@ -215,9 +217,9 @@ CFUNC int vasprintf(char **strp, const char *fmt, va_list ap);
 #define getpid _getpid
 #define RETSIGTYPE void
 #define access _access
-#define pipe(pipes) _pipe((pipes),8*1024,_O_BINARY)
 #ifndef __has_attribute
 #define   __attribute__(x)
+#endif
 #define mkdir mkdir2
 #define fileno _fileno
 #define open uni_open

--- a/unistd/unistd.h
+++ b/unistd/unistd.h
@@ -223,7 +223,7 @@ CFUNC int aprintf(char **ret, const char *format, ...);
 #endif
 #define mkdir mkdir2
 #define fileno _fileno
-#define open uni_open
+//#define open uni_open
 #define fdopen _fdopen
 #define execve _execve
 #define execv _execv

--- a/unistd/unistd.h
+++ b/unistd/unistd.h
@@ -169,6 +169,7 @@ CFUNC ssize_t getdelim(char** lineptr, size_t* n,int delim, FILE* stream);
 CFUNC ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
 CFUNC int setlinebuf(FILE *stream);
 CFUNC int vasprintf(char **strp, const char *fmt, va_list ap);
+CFUNC int aprintf(char **ret, const char *format, ...);
 
 //#define strlen unistd_safe_strlen
 //#define inet_ntop InetNtop

--- a/unistd/unistd.h
+++ b/unistd/unistd.h
@@ -40,6 +40,7 @@
 #include <sys/utime.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/random.h>
 #include <assert.h>
 #include <inttypes.h>
 #include <io.h>
@@ -153,6 +154,7 @@ CFUNC pid_t vfork();
 CFUNC double drand48();
 CFUNC void srand48(long int seedval);
 CFUNC long int random(void);
+CFUNC void srandom(unsigned int seed);
 CFUNC int setenv(const char *name, const char *value, int overwrite);
 CFUNC int unsetenv(const char *name);
 CFUNC int truncate(const char *path, off_t length);


### PR DESCRIPTION
This is the last of the changes from the Zeek project. It adds a few new methods that weren't there before, plus some cleanup that was required to build Zeek against libunistd.

The specific things I want to call out in this are:

- 6c8040003ab0c188ec33787fd349a8470ee9226a: The implementation of `dirname` causes a compiler warning because it's trying to shift a 32-bit value by 32 bits to store the high part of the offset. This could possibly just assign `OffsetHigh` to zero, but it's working for us as is.
- 58da4783e9c835175c91f6c21a7994fb611bab97: The implementation of `read()` causes the build to output a bunch of "inconsistent dll linkage" warnings when building the library outside of the Zeek project. The warnings go away with our build setup, but I haven't investigated what set of compiler flags make it do so. It does finish the build and link the libraries though.